### PR TITLE
Adds license information to the setup function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     version='0.1',
     description='Backport of Python 2.7\'s collections module',
     long_description=open('README.rst').read(),
+    license='Python-2.0',
     maintainer='Sebastian Kreft',
     url='http://github.com/sk-/backport_collections',
     py_modules=['backport_collections', 'backport_abcoll'],


### PR DESCRIPTION
As suggested in https://packaging.python.org/distributing/#license
Taken the short form of the license from https://opensource.org/licenses/Python-2.0
